### PR TITLE
feat: add staging and production environments

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  apps: [
+    {
+      name: 'moltbot-face-production',
+      script: 'npm',
+      args: 'run start:prod',
+      cwd: '/home/ubuntu/clawd/moltbot-face',
+      env: {
+        NODE_ENV: 'production',
+        PORT: 18794,
+      },
+    },
+    {
+      name: 'moltbot-face-staging',
+      script: 'npm',
+      args: 'run start:staging',
+      cwd: '/home/ubuntu/clawd/moltbot-face',
+      env: {
+        NODE_ENV: 'staging',
+        PORT: 18795,
+      },
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
   "name": "moltbot-face",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:staging": "VITE_ENV=staging vite --port 18795",
+    "dev:prod": "VITE_ENV=production vite --port 18794",
+    "start:staging": "VITE_ENV=staging vite --port 18795 --host",
+    "start:prod": "VITE_ENV=production vite --port 18794 --host",
     "build": "vite build",
-    "lint": "eslint .",
-    "preview": "vite preview"
+    "build:staging": "VITE_ENV=staging vite build --outDir dist/staging",
+    "build:prod": "VITE_ENV=production vite build --outDir dist/production",
+    "preview": "vite preview",
+    "lint": "eslint ."
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/public/config.production.json
+++ b/public/config.production.json
@@ -1,0 +1,27 @@
+{
+  "identity": {
+    "name": "Kratos",
+    "tagline": "God of Coding",
+    "emoji": "⚡"
+  },
+  "gateway": {
+    "url": "ws://127.0.0.1:18789",
+    "session": "main"
+  },
+  "theme": {
+    "primary": "#3b82f6",
+    "secondary": "#1e40af",
+    "accent": "#fbbf24",
+    "background": "#0f172a",
+    "text": "#f8fafc",
+    "glow": "rgba(59, 130, 246, 0.5)"
+  },
+  "face": {
+    "style": "geometric",
+    "eyeShape": "angular",
+    "showName": true,
+    "showStatus": true,
+    "showBubble": true
+  },
+  "environment": "production"
+}

--- a/public/config.staging.json
+++ b/public/config.staging.json
@@ -1,0 +1,27 @@
+{
+  "identity": {
+    "name": "Kratos",
+    "tagline": "God of Coding (STAGING)",
+    "emoji": "⚡"
+  },
+  "gateway": {
+    "url": "ws://127.0.0.1:18789",
+    "session": "main"
+  },
+  "theme": {
+    "primary": "#f59e0b",
+    "secondary": "#d97706",
+    "accent": "#fbbf24",
+    "background": "#1c1917",
+    "text": "#f8fafc",
+    "glow": "rgba(245, 158, 11, 0.5)"
+  },
+  "face": {
+    "style": "geometric",
+    "eyeShape": "angular",
+    "showName": true,
+    "showStatus": true,
+    "showBubble": true
+  },
+  "environment": "staging"
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,9 +9,12 @@ function App() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // Load config on mount
+  // Load config on mount based on environment
   useEffect(() => {
-    fetch('/config.json')
+    const env = import.meta.env.VITE_ENV || 'production';
+    const configFile = env === 'staging' ? '/config.staging.json' : '/config.production.json';
+    
+    fetch(configFile)
       .then(res => res.json())
       .then(data => {
         setConfig(data);
@@ -99,9 +102,12 @@ function App() {
         theme={config?.theme}
       />
 
-      {/* Fullscreen hint */}
-      <div className="absolute bottom-2 right-4 text-xs opacity-30" style={{ color: config?.theme?.text || '#fff' }}>
-        Press F11 for fullscreen
+      {/* Environment badge + Fullscreen hint */}
+      <div className="absolute bottom-2 right-4 flex items-center gap-4 text-xs opacity-30" style={{ color: config?.theme?.text || '#fff' }}>
+        {config?.environment === 'staging' && (
+          <span className="bg-amber-500/20 text-amber-400 px-2 py-1 rounded opacity-100">STAGING</span>
+        )}
+        <span>Press F11 for fullscreen</span>
       </div>
     </div>
   );

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,11 +2,16 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+const env = process.env.VITE_ENV || 'production'
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     host: '0.0.0.0',
-    port: 18794,
-    allowedHosts: ['organisation-frames-minute-electric.trycloudflare.com', '.trycloudflare.com'],
+    port: env === 'staging' ? 18795 : 18794,
+    allowedHosts: ['.trycloudflare.com', '.localhost'],
+  },
+  define: {
+    'import.meta.env.VITE_ENV': JSON.stringify(env),
   },
 })


### PR DESCRIPTION
## Summary

Adds staging and production environment support.

## Changes

- **Config files**: Separate `config.staging.json` and `config.production.json`
- **PM2 ecosystem**: `ecosystem.config.cjs` for managing both environments
- **Ports**: Staging on 18795, Production on 18794
- **Themes**: Staging has amber theme with STAGING badge, Production has blue theme
- **Scripts**: `npm run start:staging` and `npm run start:prod`

## Usage

```bash
# Start both with PM2
pm2 start ecosystem.config.cjs

# Or run individually
npm run start:staging
npm run start:prod
```

⚡ Kratos