### PR TITLE
feat: switch to generated avatar after download

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ function App() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showAvatarGenerator, setShowAvatarGenerator] = useState(false);
+  const [customAvatar, setCustomAvatar] = useState(null);
 
   // Load config on mount based on environment
   useEffect(() => {
@@ -94,6 +95,7 @@ function App() {
           state={state}
           config={config}
           theme={config?.theme}
+          customAvatar={customAvatar}
         />
       </div>
 
@@ -127,7 +129,13 @@ function App() {
           <div className="max-w-md w-full">
             <AvatarGenerator
               theme={config?.theme}
-              onAvatarGenerated={(result) => console.log('Avatar generated:', result)}
+              onAvatarGenerated={(result) => {
+                console.log('Avatar generated:', result);
+                if (result?.useAsFace) {
+                  setCustomAvatar(result.url);
+                  setShowAvatarGenerator(false);
+                }
+              }}
             />
           </div>
         </div>

--- a/src/components/AvatarGenerator.jsx
+++ b/src/components/AvatarGenerator.jsx
@@ -38,6 +38,8 @@ export function AvatarGenerator({ onAvatarGenerated, theme }) {
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+      // Notify parent to switch to this avatar
+      onAvatarGenerated?.({ url: previewUrl, useAsFace: true });
     }
   };
 

--- a/src/components/Face.jsx
+++ b/src/components/Face.jsx
@@ -1,13 +1,29 @@
 import { useMemo } from 'react';
 import { STATES } from '../hooks/useGateway';
 
-export function Face({ state, config, theme }) {
+export function Face({ state, config, theme, customAvatar }) {
   const isThinking = state === STATES.THINKING;
   const isSpeaking = state === STATES.SPEAKING;
   const isError = state === STATES.ERROR;
   const isDisconnected = state === STATES.DISCONNECTED || state === STATES.CONNECTING;
 
   const eyeStyle = config?.face?.eyeShape || 'angular';
+
+  // If custom avatar is provided, show it instead of SVG
+  if (customAvatar) {
+    return (
+      <div className="w-full h-full max-w-[80vh] max-h-[80vh] flex items-center justify-center">
+        <img
+          src={customAvatar}
+          alt="Kratos Avatar"
+          className="w-full h-full object-contain rounded-full"
+          style={{
+            boxShadow: `0 0 40px ${theme?.primary || '#3b82f6'}40`,
+          }}
+        />
+      </div>
+    );
+  }
 
   // Dynamic styles based on state
   const faceColor = useMemo(() => {


### PR DESCRIPTION
## Summary

After downloading a generated avatar, the face automatically switches from SVG to the downloaded image.

## Changes

- **Face.jsx**: Accepts `customAvatar` prop to display image instead of SVG
- **AvatarGenerator.jsx**: Triggers `useAsFace` flag on download
- **App.jsx**: Tracks `customAvatar` state and handles the switch

## How it works

1. User generates avatar
2. Clicks Download
3. Image downloads
4. Face automatically switches to the generated image
5. User can reopen generator to try different styles

## Usage

```jsx
// Face shows custom image instead of SVG
<Face customAvatar={imageUrl} />
```

⚡ Kratos