### PR TITLE
fix: show Ready status in standalone mode instead of token error

### DIFF
--- a/src/hooks/useGateway.js
+++ b/src/hooks/useGateway.js
@@ -19,7 +19,12 @@ export function useGateway(config) {
   const reconnectTimeoutRef = useRef(null);
 
   const connect = useCallback(() => {
-    if (!config?.gateway?.url) return;
+    if (!config?.gateway?.url) {
+      // No gateway configured - standalone mode
+      setState(STATES.IDLE);
+      setMessage('');
+      return;
+    }
 
     const params = new URLSearchParams(window.location.search);
     const token = params.get('token');
@@ -27,8 +32,9 @@ export function useGateway(config) {
     const wsUrl = params.get('ws') || config.gateway.url;
 
     if (!token) {
-      setState(STATES.ERROR);
-      setMessage('Missing token. Add ?token=YOUR_TOKEN to URL');
+      // Standalone mode - no gateway connection, just display face
+      setState(STATES.IDLE);
+      setMessage('');
       return;
     }
 


### PR DESCRIPTION
## Problem
When no gateway token was provided, the app showed an error message:
> Missing token. Add ?token=YOUR_TOKEN to URL

This looked bad on the Vercel deployment which is meant for standalone display.

## Solution
- Show "Ready" status (green) when no token/gateway is configured
- Standalone mode now displays cleanly without error messages

## Screenshot
![Ready status](https://github.com/giofcosta/your-moltbot-face/blob/feature/fix-standalone-status/e2e/screenshots/Mobile-Chrome-main.png?raw=true)

## Tests
✅ All 22 e2e tests pass