### PR TITLE
feat: add Use CSS Face button to switch back from custom avatar

### DIFF
--- a/e2e/ui.spec.js
+++ b/e2e/ui.spec.js
@@ -156,6 +156,12 @@ test.describe('Avatar Generator Modal', () => {
     await expect(useButton).not.toBeVisible();
   });
 
+  test('use CSS face button only shows when custom avatar is set', async ({ page }) => {
+    // Initially, "Use CSS Face" button should NOT be visible (no custom avatar)
+    const cssButton = page.locator('button:has-text("Use CSS Face")');
+    await expect(cssButton).not.toBeVisible();
+  });
+
   test('takes visual screenshot for review', async ({ page }, testInfo) => {
     // Take screenshot for visual review
     await page.screenshot({ 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -132,11 +132,15 @@ function App() {
         isOpen={showAvatarGenerator}
         onClose={() => setShowAvatarGenerator(false)}
         theme={config?.theme}
+        hasCustomAvatar={!!customAvatar}
         onAvatarGenerated={(result) => {
           console.log('Avatar generated:', result);
           if (result?.useAsFace) {
             setCustomAvatar(result.url);
           }
+        }}
+        onResetToDefault={() => {
+          setCustomAvatar(null);
         }}
       />
     </div>

--- a/src/components/AvatarGenerator.jsx
+++ b/src/components/AvatarGenerator.jsx
@@ -36,7 +36,7 @@ const styles = [
   },
 ];
 
-export function AvatarGenerator({ isOpen, onClose, theme, onAvatarGenerated }) {
+export function AvatarGenerator({ isOpen, onClose, theme, onAvatarGenerated, onResetToDefault, hasCustomAvatar }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [previewUrl, setPreviewUrl] = useState(null);
@@ -44,6 +44,12 @@ export function AvatarGenerator({ isOpen, onClose, theme, onAvatarGenerated }) {
   const [history, setHistory] = useState([]);
   const [activeTab, setActiveTab] = useState('generate');
   const { toast, showToast, hideToast } = useToast();
+
+  const handleResetToDefault = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    onResetToDefault?.();
+    showToast('Switched to CSS face!', 'success');
+  };
 
   useEffect(() => {
     const saved = localStorage.getItem(`${STORAGE_KEY}-history`);
@@ -144,12 +150,22 @@ export function AvatarGenerator({ isOpen, onClose, theme, onAvatarGenerated }) {
               <p className="text-sm text-white/50">Generate your Kratos avatar</p>
             </div>
           </div>
-          <button
-            onClick={onClose}
-            className={cn(buttonVariants({ variant: 'ghost', size: 'icon' }), 'text-white/70 hover:text-white')}
-          >
-            ✕
-          </button>
+          <div className="flex items-center gap-2">
+            {hasCustomAvatar && (
+              <button
+                onClick={handleResetToDefault}
+                className={cn(buttonVariants({ variant: 'outline', size: 'sm' }), 'text-white/70 hover:text-white')}
+              >
+                Use CSS Face
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className={cn(buttonVariants({ variant: 'ghost', size: 'icon' }), 'text-white/70 hover:text-white')}
+            >
+              ✕
+            </button>
+          </div>
         </div>
 
         {/* Tabs */}


### PR DESCRIPTION
## Changes

- Add "Use CSS Face" button in Avatar Studio header
- Button only appears when a custom avatar is currently set
- Clicking resets to original CSS-rendered face
- Clears localStorage and shows success toast

## UX
- Users can now switch back to CSS face after setting a custom avatar
- Button is hidden when already using CSS face (no confusion)
- Toast confirms the switch: "Switched to CSS face!"

## Tests
- Added e2e test for button visibility
- All 26 tests pass