### PR TITLE
feat: add bot mood indicator with colored halo

### DIFF
--- a/src/components/Face.jsx
+++ b/src/components/Face.jsx
@@ -1,11 +1,28 @@
 import { useMemo } from 'react';
 import { STATES } from '../hooks/useGateway';
+import { useMood, MOODS } from '../hooks/useMood';
 
 export function Face({ state, config, theme, customAvatar }) {
   const isThinking = state === STATES.THINKING;
   const isSpeaking = state === STATES.SPEAKING;
   const isError = state === STATES.ERROR;
   const isDisconnected = state === STATES.DISCONNECTED || state === STATES.CONNECTING;
+  
+  // Get mood from local memory
+  const { mood } = useMood(state);
+
+  // Mood colors
+  const moodColor = useMemo(() => {
+    switch (mood) {
+      case MOODS.HAPPY:
+        return '#22c55e'; // Green
+      case MOODS.ANGRY:
+        return '#ef4444'; // Red
+      case MOODS.NEUTRAL:
+      default:
+        return '#eab308'; // Yellow
+    }
+  }, [mood]);
 
   const eyeStyle = config?.face?.eyeShape || 'angular';
 
@@ -13,24 +30,40 @@ export function Face({ state, config, theme, customAvatar }) {
   if (customAvatar) {
     return (
       <div className="w-full h-full max-w-[70vh] max-h-[70vh] flex items-center justify-center p-8">
-        <div 
-          className="relative w-full aspect-square rounded-full overflow-hidden"
-          style={{
-            boxShadow: `0 0 60px ${theme?.primary || '#3b82f6'}60, inset 0 0 60px ${theme?.primary || '#3b82f6'}20`,
-            border: `3px solid ${theme?.primary || '#3b82f6'}80`,
-          }}
-        >
-          <img
-            src={customAvatar}
-            alt="Kratos Avatar"
-            className="w-full h-full object-cover"
-          />
-          {/* Glow ring */}
+        <div className="relative">
+          {/* Mood halo */}
           <div 
-            className="absolute inset-0 rounded-full pointer-events-none"
+            className="absolute -inset-4 rounded-full animate-pulse"
             style={{
-              boxShadow: `inset 0 0 30px ${theme?.primary || '#3b82f6'}40`,
+              background: `radial-gradient(circle, ${moodColor}40 0%, ${moodColor}20 40%, transparent 70%)`,
+              boxShadow: `0 0 40px ${moodColor}60, 0 0 80px ${moodColor}40`,
             }}
+          />
+          <div 
+            className="relative w-full aspect-square rounded-full overflow-hidden"
+            style={{
+              boxShadow: `0 0 60px ${theme?.primary || '#3b82f6'}60, inset 0 0 60px ${theme?.primary || '#3b82f6'}20`,
+              border: `3px solid ${theme?.primary || '#3b82f6'}80`,
+            }}
+          >
+            <img
+              src={customAvatar}
+              alt="Kratos Avatar"
+              className="w-full h-full object-cover"
+            />
+            {/* Glow ring */}
+            <div 
+              className="absolute inset-0 rounded-full pointer-events-none"
+              style={{
+                boxShadow: `inset 0 0 30px ${theme?.primary || '#3b82f6'}40`,
+              }}
+            />
+          </div>
+          {/* Mood indicator dot */}
+          <div 
+            className="absolute -bottom-1 -right-1 w-6 h-6 rounded-full border-2 border-white"
+            style={{ backgroundColor: moodColor }}
+            title={`Mood: ${mood}`}
           />
         </div>
       </div>
@@ -51,15 +84,31 @@ export function Face({ state, config, theme, customAvatar }) {
   }, [isThinking, isSpeaking]);
 
   return (
-    <svg
-      viewBox="0 0 400 400"
-      className={`w-full h-full max-w-[80vh] max-h-[80vh] transition-all duration-300 ${
-        isThinking ? 'animate-thinking' : ''
-      }`}
-      style={{
-        filter: `drop-shadow(${glowIntensity} ${faceColor}40)`,
-      }}
-    >
+    <div className="relative">
+      {/* Mood halo for SVG face */}
+      <div 
+        className="absolute inset-0 rounded-full animate-pulse pointer-events-none"
+        style={{
+          background: `radial-gradient(circle, ${moodColor}30 0%, ${moodColor}15 40%, transparent 70%)`,
+          boxShadow: `0 0 60px ${moodColor}50, 0 0 100px ${moodColor}30`,
+          transform: 'scale(1.1)',
+        }}
+      />
+      {/* Mood indicator dot */}
+      <div 
+        className="absolute bottom-4 right-4 w-5 h-5 rounded-full border-2 border-white z-10"
+        style={{ backgroundColor: moodColor }}
+        title={`Mood: ${mood}`}
+      />
+      <svg
+        viewBox="0 0 400 400"
+        className={`w-full h-full max-w-[80vh] max-h-[80vh] transition-all duration-300 relative z-0 ${
+          isThinking ? 'animate-thinking' : ''
+        }`}
+        style={{
+          filter: `drop-shadow(${glowIntensity} ${faceColor}40)`,
+        }}
+      >
       {/* Background circle */}
       <circle
         cx="200"
@@ -224,5 +273,6 @@ export function Face({ state, config, theme, customAvatar }) {
         }}
       />
     </svg>
+    </div>
   );
 }

--- a/src/hooks/useMood.js
+++ b/src/hooks/useMood.js
@@ -1,0 +1,126 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const MOODS = {
+  HAPPY: 'happy',    // Green - recent positive interactions
+  ANGRY: 'angry',    // Red - recent errors or negative feedback
+  NEUTRAL: 'neutral', // Yellow - default/no recent activity
+};
+
+const STORAGE_KEY = 'moltbot-mood-history';
+const MAX_HISTORY = 50; // Keep last 50 interactions
+
+/**
+ * Mood detection based on local memory (no API calls)
+ * Tracks interaction history to determine emotional state
+ */
+export function useMood(state) {
+  const [mood, setMood] = useState(MOODS.NEUTRAL);
+
+  // Load mood history from localStorage
+  const getMoodHistory = useCallback(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  }, []);
+
+  // Save interaction to history
+  const recordInteraction = useCallback((type, sentiment = 'neutral') => {
+    try {
+      const history = getMoodHistory();
+      const entry = {
+        timestamp: Date.now(),
+        type, // 'success', 'error', 'chat', 'feedback'
+        sentiment, // 'positive', 'negative', 'neutral'
+      };
+      
+      const newHistory = [entry, ...history].slice(0, MAX_HISTORY);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(newHistory));
+      
+      // Recalculate mood
+      calculateMood(newHistory);
+    } catch (e) {
+      console.error('Failed to record interaction:', e);
+    }
+  }, [getMoodHistory]);
+
+  // Calculate mood based on recent history
+  const calculateMood = useCallback((history) => {
+    if (history.length === 0) {
+      setMood(MOODS.NEUTRAL);
+      return;
+    }
+
+    // Weight recent interactions more heavily (last 10)
+    const recent = history.slice(0, 10);
+    let score = 0;
+    
+    recent.forEach((entry, index) => {
+      const weight = (10 - index) / 10; // More recent = higher weight
+      
+      switch (entry.sentiment) {
+        case 'positive':
+        case 'success':
+          score += weight * 2;
+          break;
+        case 'negative':
+        case 'error':
+          score -= weight * 3; // Errors weigh more heavily
+          break;
+        default:
+          score += weight * 0.5; // Neutral slight positive
+      }
+    });
+
+    // Determine mood based on score
+    if (score > 3) {
+      setMood(MOODS.HAPPY);
+    } else if (score < -2) {
+      setMood(MOODS.ANGRY);
+    } else {
+      setMood(MOODS.NEUTRAL);
+    }
+  }, []);
+
+  // Track state changes to record interactions
+  useEffect(() => {
+    if (state === 'error') {
+      recordInteraction('state_change', 'negative');
+    } else if (state === 'speaking') {
+      recordInteraction('state_change', 'positive');
+    }
+  }, [state, recordInteraction]);
+
+  // Initialize mood on mount
+  useEffect(() => {
+    const history = getMoodHistory();
+    calculateMood(history);
+  }, [getMoodHistory, calculateMood]);
+
+  // Manual mood setters for external control
+  const setHappy = useCallback(() => {
+    recordInteraction('manual', 'positive');
+  }, [recordInteraction]);
+
+  const setAngry = useCallback(() => {
+    recordInteraction('manual', 'negative');
+  }, [recordInteraction]);
+
+  const setNeutral = useCallback(() => {
+    recordInteraction('manual', 'neutral');
+  }, [recordInteraction]);
+
+  return {
+    mood,
+    MOODS,
+    recordInteraction,
+    setHappy,
+    setAngry,
+    setNeutral,
+    getMoodHistory,
+  };
+}
+
+export { MOODS };


### PR DESCRIPTION
## Summary
Implements bot mood feature as requested in #16.

## Changes
- Added `useMood` hook that tracks mood from local memory (localStorage)
- Mood is determined by recent interaction history (success = happy, error = angry, neutral = default)
- Added colored halo around avatar:
  - 🟢 **Green** = Happy (recent positive interactions)
  - 🔴 **Red** = Angry (recent errors/negative feedback)
  - 🟡 **Yellow** = Neutral (default/no recent activity)
- Works with both custom avatar and SVG face views
- No API calls or token usage - purely local memory-based

## How it works
1. Tracks interactions in localStorage (last 50)
2. Weights recent interactions more heavily
3. Calculates mood score and displays appropriate color
4. Shows mood indicator dot in bottom-right corner

Closes #16