### PR TITLE
fix: move breathingSpeed declaration before early return

### DIFF
--- a/src/components/Face.jsx
+++ b/src/components/Face.jsx
@@ -26,6 +26,13 @@ export function Face({ state, config, theme, customAvatar }) {
 
   const eyeStyle = config?.face?.eyeShape || 'angular';
 
+  // Breathing animation speed based on state (must be before early return)
+  const breathingSpeed = useMemo(() => {
+    if (isThinking || isSpeaking) return '0.8s'; // Fast when active
+    if (state === STATES.LISTENING) return '2s'; // Medium when listening
+    return '4s'; // Slow when idle
+  }, [isThinking, isSpeaking, state]);
+
   // If custom avatar is provided, show it instead of SVG
   if (customAvatar) {
     return (
@@ -64,13 +71,6 @@ export function Face({ state, config, theme, customAvatar }) {
       </div>
     );
   }
-
-  // Breathing animation speed based on state
-  const breathingSpeed = useMemo(() => {
-    if (isThinking || isSpeaking) return '0.8s'; // Fast when active
-    if (state === STATES.LISTENING) return '2s'; // Medium when listening
-    return '4s'; // Slow when idle
-  }, [isThinking, isSpeaking, state]);
 
   // Dynamic styles based on state
   const faceColor = useMemo(() => {


### PR DESCRIPTION
## Problem
Staging is broken with error: `Uncaught ReferenceError: Cannot access 'M' before initialization`

## Root Cause
In PR #35, the `breathingSpeed` variable was used inside the custom avatar early-return block, but defined AFTER that block. When a custom avatar is set, JavaScript tries to access the variable before it's declared.

## Fix
Moved the `breathingSpeed` useMemo declaration BEFORE the early return for custom avatar.

## Testing
- [x] Build passes
- [x] All 26 tests pass
- [x] Verified `breathingSpeed` is now defined on line 30, before use on lines 47 and 97

Closes #36