### PR TITLE
feat: make face fill 80% of container area (#64)

### DIFF
--- a/src/components/Face.jsx
+++ b/src/components/Face.jsx
@@ -62,7 +62,7 @@ export function Face({ state, config, theme, customAvatar }) {
   // If custom avatar is provided, show it instead of SVG
   if (customAvatar) {
     return (
-      <div ref={containerRef} className="w-full h-full max-w-[85vh] max-h-[85vh] flex items-center justify-center p-4 relative">
+      <div ref={containerRef} className="w-[80%] h-[80%] max-w-[600px] max-h-[600px] flex items-center justify-center relative">
         {/* Particle System */}
         <ParticleSystem 
           state={state} 
@@ -120,7 +120,7 @@ export function Face({ state, config, theme, customAvatar }) {
   }, [expressionConfig.glowIntensity]);
 
   return (
-    <div ref={containerRef} className="relative">
+    <div ref={containerRef} className="relative w-[80%] h-[80%] max-w-[600px] max-h-[600px] aspect-square">
       {/* Particle System */}
       <ParticleSystem 
         state={state} 
@@ -143,7 +143,7 @@ export function Face({ state, config, theme, customAvatar }) {
       <div data-testid="face-tilt-wrapper" style={tiltStyle}>
         <svg
         viewBox="0 0 400 400"
-        className={`w-full h-full max-w-[90vh] max-h-[90vh] transition-all duration-300 relative z-0 ${
+        className={`w-full h-full transition-all duration-300 relative z-0 ${
           isThinking ? 'animate-thinking' : ''
         }`}
         style={{


### PR DESCRIPTION
## Summary
Makes the face fill 80% of the container area instead of using viewport height units.

## Changes
- SVG face: w-[80%] h-[80%] max-w-[600px] max-h-[600px] aspect-square
- Custom avatar: w-[80%] h-[80%] max-w-[600px] max-h-[600px]
- Removed vh-based sizing

## Testing
- 80 tests pass, 10 skipped
- Works on both mobile and desktop

Closes #64