### PR TITLE
feat(avatar): add provider selection dropdown

### DIFF
--- a/e2e/avatar-generation.spec.js
+++ b/e2e/avatar-generation.spec.js
@@ -157,4 +157,30 @@ test.describe('Avatar Generation', () => {
       await expect(styleBtn).toHaveClass(/border-primary|border-\[/);
     }
   });
+
+  test('provider selection changes the avatar provider', async ({ page }) => {
+    // Open avatar generator
+    await page.click('text=Generate');
+    await page.waitForSelector('text=Avatar Studio');
+
+    // Check that provider section heading is visible
+    await expect(page.getByRole('heading', { name: 'Provider' })).toBeVisible();
+
+    // Check default footer shows DiceBear
+    await expect(page.locator('text=Powered by DiceBear')).toBeVisible();
+
+    // Select Pollinations AI - use the button in the provider section
+    const pollinationsBtn = page.getByRole('button', { name: /Pollinations AI/ }).first();
+    await pollinationsBtn.click();
+    
+    // Footer should update
+    await expect(page.locator('text=Powered by Pollinations AI')).toBeVisible();
+
+    // Select Robohash
+    const robohashBtn = page.getByRole('button', { name: /Robohash/ }).first();
+    await robohashBtn.click();
+    
+    // Footer should update
+    await expect(page.locator('text=Powered by Robohash')).toBeVisible();
+  });
 });

--- a/src/components/AvatarGenerator.jsx
+++ b/src/components/AvatarGenerator.jsx
@@ -5,6 +5,28 @@ import { Toast, useToast } from './Toast';
 
 const STORAGE_KEY = 'kratos-custom-avatar';
 
+// Available avatar providers
+const PROVIDERS = [
+  {
+    id: 'dicebear',
+    name: 'DiceBear',
+    description: 'Reliable SVG avatars',
+    icon: '🔷',
+  },
+  {
+    id: 'pollinations',
+    name: 'Pollinations AI',
+    description: 'AI-generated (may be slow)',
+    icon: '🎨',
+  },
+  {
+    id: 'robohash',
+    name: 'Robohash',
+    description: 'Robot-style avatars',
+    icon: '🤖',
+  },
+];
+
 const styles = [
   {
     id: 'kratos',
@@ -45,6 +67,7 @@ export function AvatarGenerator({ isOpen, onClose, theme, onAvatarGenerated, onR
   const [imageLoading, setImageLoading] = useState(false);
   const [imageError, setImageError] = useState(false);
   const [selectedStyle, setSelectedStyle] = useState('kratos');
+  const [selectedProvider, setSelectedProvider] = useState('dicebear');
   const [history, setHistory] = useState([]);
   const [activeTab, setActiveTab] = useState('generate');
   const { toast, showToast, hideToast } = useToast();
@@ -83,6 +106,7 @@ export function AvatarGenerator({ isOpen, onClose, theme, onAvatarGenerated, onR
       const result = await generateKratosAvatar(selectedStyle, {
         width: 512,
         height: 512,
+        provider: selectedProvider,
       });
 
       if (result.success) {
@@ -249,6 +273,36 @@ export function AvatarGenerator({ isOpen, onClose, theme, onAvatarGenerated, onR
                           style={{ background: theme?.primary }}
                         />
                       )}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Provider Selection */}
+                <h3 className="text-sm font-semibold text-white/70 uppercase tracking-wider">
+                  Provider
+                </h3>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                  {PROVIDERS.map((provider) => (
+                    <button
+                      key={provider.id}
+                      onClick={() => setSelectedProvider(provider.id)}
+                      className={cn(
+                        'relative p-3 rounded-lg border-2 text-left transition-all',
+                        selectedProvider === provider.id
+                          ? 'border-primary bg-primary/10'
+                          : 'border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/10'
+                      )}
+                      style={{
+                        borderColor: selectedProvider === provider.id ? theme?.primary : undefined,
+                      }}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-base">{provider.icon}</span>
+                        <div className="min-w-0">
+                          <div className="font-medium text-white text-sm truncate">{provider.name}</div>
+                          <div className="text-xs text-white/40 truncate">{provider.description}</div>
+                        </div>
+                      </div>
                     </button>
                   ))}
                 </div>
@@ -427,7 +481,7 @@ export function AvatarGenerator({ isOpen, onClose, theme, onAvatarGenerated, onR
 
         {/* Footer */}
         <div className="px-4 sm:px-6 lg:px-8 py-3 sm:py-4 border-t border-white/10 text-center text-xs text-white/40">
-          Powered by Pollinations.ai • Free unlimited generation
+          Powered by {PROVIDERS.find(p => p.id === selectedProvider)?.name || 'DiceBear'}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add provider selection UI to Avatar Studio with 3 options:
  - **DiceBear** (default) - Reliable SVG avatars
  - **Pollinations AI** - AI-generated (may be slow)
  - **Robohash** - Robot-style avatars
- Footer dynamically shows selected provider
- Provider selection passed to avatar generation function

## Test Plan
- [x] All 14 avatar generation tests pass
- [x] New test added for provider selection functionality
- [x] Manually verified UI in browser

Closes #69