### PR TITLE
fix(ci): use PROJECT_TOKEN for project board access

### DIFF
--- a/.github/workflows/auto-move-project-cards.yml
+++ b/.github/workflows/auto-move-project-cards.yml
@@ -1,5 +1,14 @@
 name: Auto-move Project Cards
 
+# This workflow moves project cards when PRs are opened or merged.
+# IMPORTANT: Requires a Personal Access Token (PAT) with 'project' scope
+# stored as repository secret named PROJECT_TOKEN.
+# 
+# To create the PAT:
+# 1. Go to GitHub Settings > Developer settings > Personal access tokens
+# 2. Create a classic token with 'project' scope (for Projects V2)
+# 3. Add it as a repository secret named PROJECT_TOKEN
+
 on:
   pull_request:
     types: [opened, closed]
@@ -20,7 +29,7 @@ jobs:
         if: github.event.action == 'opened'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             console.log('=== Move to PR opened ===');
             console.log('PR body:', context.payload.pull_request.body);
@@ -159,7 +168,7 @@ jobs:
         if: github.event.action == 'closed' && github.event.pull_request.merged == true
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
             console.log('=== Move to Done ===');
             console.log('PR merged:', context.payload.pull_request.merged);

--- a/README.md
+++ b/README.md
@@ -163,6 +163,34 @@ The face responds to Gateway events with these visual states:
 - SVG animations
 - WebSocket (Moltbot Gateway protocol)
 
+## GitHub Actions Setup
+
+The project uses GitHub Actions for CI and automatic project board management.
+
+### Auto-move Project Cards Workflow
+
+This workflow automatically moves project cards when PRs are opened or merged.
+
+**Required Setup:**
+
+1. **Create a Personal Access Token (PAT):**
+   - Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
+   - Click "Generate new token (classic)"
+   - Give it a descriptive name (e.g., "openclaw-face-project-token")
+   - Select the `project` scope (for Projects V2 access)
+   - Click "Generate token" and copy it
+
+2. **Add as Repository Secret:**
+   - Go to your repository → Settings → Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `PROJECT_TOKEN`
+   - Value: Paste the PAT you created
+   - Click "Add secret"
+
+**Why is this needed?**
+
+The default `GITHUB_TOKEN` provided by Actions cannot access user-owned Projects V2. A Personal Access Token with `project` scope is required to read and update project items.
+
 ## License
 
 MIT — Make it yours! ⚡


### PR DESCRIPTION
## Summary

This PR fixes issue #74 - the pipeline issue where merged PRs weren't moving associated issues to the Done column.

### Root Cause

The workflow was using `GITHUB_TOKEN` which cannot access **user-owned Projects V2**. The GraphQL query was returning empty `projectItems` because the token lacked permissions.

From the Action logs:
```
"projectItems": {
  "nodes": []
}
Issue not found or not in any project
```

### Solution

Changed the workflow to use a Personal Access Token (PAT) with `project` scope:
- Updated `secrets.GITHUB_TOKEN` → `secrets.PROJECT_TOKEN`
- Added documentation in README explaining how to set up the PAT

### Required Action After Merge

**Giovanni needs to add the `PROJECT_TOKEN` secret:**

1. Create a PAT at GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
2. Select the `project` scope
3. Add it as repository secret named `PROJECT_TOKEN`

### Test Plan

- [x] Verified the root cause from Action logs
- [x] Updated workflow to use PROJECT_TOKEN
- [x] Added setup documentation to README

Closes #74