### PR TITLE
fix: align CSS face halo with avatar mode positioning

### DIFF
--- a/src/components/Face.jsx
+++ b/src/components/Face.jsx
@@ -120,7 +120,7 @@ export function Face({ state, config, theme, customAvatar }) {
   }, [expressionConfig.glowIntensity]);
 
   return (
-    <div ref={containerRef} className="relative w-[80%] h-[80%] max-w-[600px] max-h-[600px] aspect-square">
+    <div ref={containerRef} className="w-[80%] h-[80%] max-w-[600px] max-h-[600px] flex items-center justify-center relative">
       {/* Particle System */}
       <ParticleSystem 
         state={state} 
@@ -129,30 +129,26 @@ export function Face({ state, config, theme, customAvatar }) {
       />
       {/* Weather Atmosphere */}
       <WeatherAtmosphere enabled={config?.animations?.weather !== false} theme={theme} />
-      {/* Mood halo for SVG face with breathing animation */}
-      <div
-        className="absolute rounded-full pointer-events-none z-10"
-        style={{
-          top: '-10%',
-          left: '-10%',
-          width: '120%',
-          height: '120%',
-          background: `radial-gradient(circle, ${moodColor}30 0%, ${moodColor}15 40%, transparent 70%)`,
-          boxShadow: `0 0 60px ${moodColor}50, 0 0 100px ${moodColor}30`,
-          animation: `breathe ${breathingSpeed} ease-in-out infinite`,
-        }}
-      />
       {/* Face container with 3D tilt */}
-      <div data-testid="face-tilt-wrapper" style={tiltStyle}>
+      <div className="relative z-10 w-full aspect-square" data-testid="face-tilt-wrapper" style={tiltStyle}>
+        {/* Mood halo for SVG face with breathing animation - now inside tilt wrapper like avatar mode */}
+        <div
+          className="absolute -inset-4 rounded-full pointer-events-none"
+          style={{
+            background: `radial-gradient(circle, ${moodColor}40 0%, ${moodColor}20 40%, transparent 70%)`,
+            boxShadow: `0 0 40px ${moodColor}60, 0 0 80px ${moodColor}40`,
+            animation: `breathe ${breathingSpeed} ease-in-out infinite`,
+          }}
+        />
         <svg
-        viewBox="0 0 400 400"
-        className={`w-full h-full transition-all duration-300 relative z-0 ${
-          isThinking ? 'animate-thinking' : ''
-        }`}
-        style={{
-          filter: `drop-shadow(${glowIntensity} ${faceColor}40)`,
-        }}
-      >
+          viewBox="0 0 400 400"
+          className={`w-full h-full transition-all duration-300 relative z-0 ${
+            isThinking ? 'animate-thinking' : ''
+          }`}
+          style={{
+            filter: `drop-shadow(${glowIntensity} ${faceColor}40)`,
+          }}
+        >
       {/* Background circle */}
       <circle
         cx="200"
@@ -316,7 +312,7 @@ export function Face({ state, config, theme, customAvatar }) {
           opacity: 0.5,
         }}
       />
-    </svg>
+        </svg>
       </div> {/* Close the 3D tilt wrapper */}
     </div>
   );


### PR DESCRIPTION
## Summary
Fixes the halo positioning for CSS/SVG face mode to match the avatar mode.

## Problem
The halo around the CSS face was not fitting properly like it does for the avatar mode (see issue #75).

## Solution
- Moved the mood halo **inside** the tilt wrapper (consistent with avatar mode)
- Changed to `-inset-4` positioning for uniform extension beyond face edges
- Added `w-full aspect-square` to tilt wrapper for proper sizing
- Matched container class with avatar mode (`flex items-center justify-center relative`)
- Fixed SVG indentation

## Testing
- ✅ Build passes
- ✅ All 82 tests pass (10 skipped as expected)

Fixes #75