### PR TITLE
fix: CSS face switching error - Rules of Hooks violation

### DIFF
--- a/src/components/Face.jsx
+++ b/src/components/Face.jsx
@@ -59,6 +59,19 @@ export function Face({ state, config, theme, customAvatar }) {
     return '4s'; // Slow when idle
   }, [isThinking, isSpeaking, state]);
 
+  // Dynamic styles based on state (must be before early return - Rules of Hooks)
+  const faceColor = useMemo(() => {
+    if (isError) return '#ef4444';
+    if (isDisconnected) return '#64748b';
+    return theme?.primary || '#3b82f6';
+  }, [isError, isDisconnected, theme]);
+
+  const glowIntensity = useMemo(() => {
+    // Use expression config for dynamic glow
+    const intensity = Math.round(30 + expressionConfig.glowIntensity * 50);
+    return `0 0 ${intensity}px`;
+  }, [expressionConfig.glowIntensity]);
+
   // If custom avatar is provided, show it instead of SVG
   if (customAvatar) {
     return (
@@ -105,19 +118,6 @@ export function Face({ state, config, theme, customAvatar }) {
       </div>
     );
   }
-
-  // Dynamic styles based on state
-  const faceColor = useMemo(() => {
-    if (isError) return '#ef4444';
-    if (isDisconnected) return '#64748b';
-    return theme?.primary || '#3b82f6';
-  }, [isError, isDisconnected, theme]);
-
-  const glowIntensity = useMemo(() => {
-    // Use expression config for dynamic glow
-    const intensity = Math.round(30 + expressionConfig.glowIntensity * 50);
-    return `0 0 ${intensity}px`;
-  }, [expressionConfig.glowIntensity]);
 
   return (
     <div ref={containerRef} className="w-[80%] h-[80%] max-w-[600px] max-h-[600px] flex items-center justify-center relative">


### PR DESCRIPTION
## Summary
Fixes the blank page error that occurred when switching between CSS face and Avatar modes.

## Problem
When clicking "Use CSS Face" or "Use as Face" to switch modes, the page would go blank with a console error (React hooks order mismatch).

## Root Cause
**Rules of Hooks violation** - `useMemo` hooks for `faceColor` and `glowIntensity` were being called AFTER the early return for avatar mode.

```jsx
// BEFORE (broken)
if (customAvatar) {
  return ( /* avatar JSX */ );  // Early return skips the hooks below
}

const faceColor = useMemo(() => { ... });  // ❌ Called only when !customAvatar
const glowIntensity = useMemo(() => { ... });  // ❌ Called only when !customAvatar
```

React hooks must always be called in the same order on every render. When `customAvatar` changed from URL to `null` (switching to CSS mode), React expected the same hooks order but now encountered hooks that were previously skipped.

## Solution
Moved all `useMemo` hooks BEFORE the conditional return:

```jsx
// AFTER (fixed)
const faceColor = useMemo(() => { ... });  // ✅ Always called
const glowIntensity = useMemo(() => { ... });  // ✅ Always called

if (customAvatar) {
  return ( /* avatar JSX */ );  // Early return is now safe
}
```

## Testing
- ✅ Build passes
- ✅ All 82 tests pass (10 skipped as expected)

Fixes #73