### PR TITLE
feat: rename 'Generate Avatar' button to 'Avatar Studio' (#82)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -204,7 +204,7 @@ function App() {
             style={{ color: activeTheme.text }}
           >
             <span>⚡</span>
-            <span>{showAvatarGenerator ? 'Back to Face' : 'Generate Avatar'}</span>
+            <span>{showAvatarGenerator ? 'Back to Face' : 'Avatar Studio'}</span>
           </button>
           
           {/* Audio Reactive Toggle */}


### PR DESCRIPTION
## Summary
Renames the main button from 'Generate Avatar' to 'Avatar Studio' as requested.

## Changes
- Updated button text in App.jsx from 'Generate Avatar' to 'Avatar Studio'
- The generate button **inside** the modal remains as 'Generate Avatar' (describes the action)

## Testing
- Build passes ✅
- UI tests pass ✅

Closes #82